### PR TITLE
Enables env variables for tokens.

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,9 @@ function cli() {
       logs: true,
       dockerEvents: true,
       'statsinterval': 30,
-      add: []
+      add: [],
+      logstoken: process.env.LOGENTRIES_LOGSTOKEN || process.env.LOGENTRIES_TOKEN,
+      statstoken: process.env.LOGENTRIES_STATSTOKEN || process.env.LOGENTRIES_TOKEN
     }
   });
 


### PR DESCRIPTION
I wasn’t able to use my env variable `LOGENTRIES_TOKEN` directly inside this docker-compose.yml: 

```yml
logentries:
  image: logentries/docker-logentries
  volumes:
    - /var/run/docker.sock:/var/run/docker.sock
  volumes_from:
    - data
  env_file: .env-dev
  command: -t $LOGENTRIES_TOKEN —no-stats -j
```

Therefore this commit adds the support for three env variables:
  * `LOGENTRIES_TOKEN`
  * `LOGENTRIES_LOGSTOKEN`
  * `LOGENTRIES_STATSTOKEN`

This allows me to keep my env variables in an external env-file using a docker-compose.yml like this:

```yml
logentries:
  image: logentries/docker-logentries
  volumes:
    - /var/run/docker.sock:/var/run/docker.sock
  volumes_from:
    - data
  env_file: .env-dev
  command: —no-stats -j
```
