### PR TITLE
added log downsampling with averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the Logentries community pack at [http://revelops.com/community/packs/docker
 
 ## Usage as a Container
 
-The simplest way to forward all your container's log to LogEntries is to
+The simplest way to forward all your container's log to Logentries is to
 run this repository as a container, with:
 
 ```sh
@@ -21,13 +21,15 @@ docker run -v /var/run/docker.sock:/var/run/docker.sock logentries/docker-logent
 ```
 
 You can also pass the `--no-stats` flag if you do not want stats to be
-published to logentries every second. You __need this flag for Docker
+published to Logentries every second. You __need this flag for Docker
 version < 1.5__.
 
 You can also pass the `--no-logs` flag if you do not want logs to be
-published to logentries.
+published to Logentries.
 
-You can also filter filter the containers for whitch the logs/stats are
+The `-i <STATSINTERVAL>` downsamples the logs sent to Logentries. It collects samples and averages them before sending to Logentries.
+
+You can also filter filter the containers for which the logs/stats are
 forwarded with:
 
 * `--matchByName REGEXP`: forward logs/stats only for the containers whose name matches the given REGEXP.
@@ -53,9 +55,10 @@ docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock logentries/
 You can also pass the `-j` switch if you log in JSON format, like
 [bunyan](http://npm.im/bunyan).
 You can also pass the `--no-stats` flag if you do not want stats to be
-published to logentries every second.
+published to Logentries every second.
 The `-a/--add` flag allows to add fixed values to the data being
 published. This follows the format 'name=value'.
+The `-i/--statsinterval` downsamples the logs sent to Logentries. It collects samples and averages them before sending to Logentries.
 
 You can also filter filter the containers for whitch the logs/stats are
 forwarded with:

--- a/example.js
+++ b/example.js
@@ -2,7 +2,8 @@
 var logentries = require('./')({
   json: false, // or true to parse lines as JSON
   secure: false, // or true to connect securely
-  token: process.env.TOKEN
+  token: process.env.TOKEN,
+  statsinterval: 5 // collect 5 logs, average them and send result to Logentries
 });
 
 // logentries is the source stream with all the

--- a/index.js
+++ b/index.js
@@ -119,6 +119,7 @@ function cli() {
       'statstoken': 'k',
       'secure': 's',
       'json': 'j',
+      'statsinterval': 'i',
       'add': 'a'
     },
     default: {
@@ -126,6 +127,7 @@ function cli() {
       stats: true,
       logs: true,
       dockerEvents: true,
+      'statsinterval': 1,
       add: []
     }
   });
@@ -133,7 +135,8 @@ function cli() {
   if (!(argv.token || (argv.logstoken && argv.statstoken))) {
     console.log('Usage: docker-logentries [-l LOGSTOKEN] [-k STATSTOKEN]\n' +
                 '                         [-t TOKEN] [--secure] [--json]\n' +
-                '                         [--no-stats] [--no-logs] [--no-dockerEvents] [-a KEY=VALUE]\n' +
+                '                         [--no-stats] [--no-logs] [--no-dockerEvents]\n' +
+                '                         [-i STATSINTERVAL] [-a KEY=VALUE]\n' +
                 '                         [--matchByImage REGEXP] [--matchByName REGEXP]\n' +
                 '                         [--skipByImage REGEXP] [--skipByName REGEXP]');
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docker-logentries",
-  "version": "0.4.1",
-  "description": "Forward all logs from all running docker containers to LogEntries",
+  "version": "0.5.0",
+  "description": "Forward all logs from all running docker containers to Logentries",
   "repository": {
     "type": "git",
     "url": "https://github.com/nearform/docker-logentries.git"
@@ -16,7 +16,7 @@
     "docker-allcontainers": "^0.4.0",
     "docker-event-log": "^0.1.2",
     "docker-loghose": "^0.6.0",
-    "docker-stats": "^0.4.0",
+    "docker-stats": "^0.5.0",
     "dockerode": "^2.2.2",
     "end-of-stream": "^1.1.0",
     "minimist": "^1.1.1",


### PR DESCRIPTION
Added the -i | --statsinterval parameter to be able to use the downsampling feature from docker-stats 0.5.0
This feature reduces the 1 second logging to the specified time interval. The downsampling is made by averaging the collected logs.

Fixed also name casing in docs.