### PR TITLE
Separate tokens for logs, events. Tokens can be used also one at a time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,23 @@ run this repository as a container, with:
 docker run -v /var/run/docker.sock:/var/run/docker.sock logentries/docker-logentries -t <TOKEN> -j -a host=`uname -n`
 ```
 
-You can also use two different tokens for logging and stats:
+You can also use different tokens for logging, stats and events:
 ```sh
-docker run -v /var/run/docker.sock:/var/run/docker.sock logentries/docker-logentries -l <LOGSTOKEN> -k <STATSTOKEN> -j -a host=`uname -n`
+docker run -v /var/run/docker.sock:/var/run/docker.sock logentries/docker-logentries -l <LOGSTOKEN> -k <STATSTOKEN> -e <EVENTSTOKEN> -j -a host=`uname -n`
 ```
 
-You can also pass the `--no-stats` flag if you do not want stats to be
+You can pass the `--no-stats` flag if you do not want stats to be
 published to Logentries every second. You __need this flag for Docker
 version < 1.5__.
 
-You can also pass the `--no-logs` flag if you do not want logs to be
+You can pass the `--no-logs` flag if you do not want logs to be published to Logentries.
+
+You can pass the `--no-dockerEvents` flag if you do not want events to be
 published to Logentries.
 
-The `-i <STATSINTERVAL>` downsamples the logs sent to Logentries. It collects samples and averages them before sending to Logentries.
+The `-i/--statsinterval <STATSINTERVAL>` downsamples the logs sent to Logentries. It collects samples and averages them before sending to Logentries.
+
+If you don't use `-a` a default ``host=`uname -n` `` value will be added.
 
 You can also filter filter the containers for which the logs/stats are
 forwarded with:
@@ -54,10 +58,18 @@ docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock logentries/
 
 You can also pass the `-j` switch if you log in JSON format, like
 [bunyan](http://npm.im/bunyan).
-You can also pass the `--no-stats` flag if you do not want stats to be
+
+You can pass the `--no-stats` flag if you do not want stats to be
 published to Logentries every second.
+
+You can pass the `--no-logs` flag if you do not want logs to be published to Logentries.
+
+You can pass the `--no-dockerEvents` flag if you do not want events to be
+published to Logentries.
+
 The `-a/--add` flag allows to add fixed values to the data being
 published. This follows the format 'name=value'.
+
 The `-i/--statsinterval` downsamples the logs sent to Logentries. It collects samples and averages them before sending to Logentries.
 
 You can also filter filter the containers for whitch the logs/stats are

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-logentries",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Forward all logs from all running docker containers to Logentries",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Users can specify token for event logs,
- Users can specify token for stdout, stderr logs,
- If -a is not added host=`uname -n` is added by default,
- The -k, -l, -e parameters can be used now separately one at a time or together (previously they worked only together),
- Fixed the --no-logs that was crashing when used,
- Improved the fact that the out stream was closed when loghose closed. Now it waits for logs, stats and events streams to close before closing the out stream,
- Added better protection to parameter parsing,
- Added better protection to unknown packages on stream,
- Added the --help option
- Updated docs and MINOR package version

Tested cli, docker container and example.js