### PR TITLE
Added newline parameter and updated loghose

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ var logentries = require('docker-logentries')({
   json: false, // or true to parse lines as JSON
   secure: false, // or true to connect securely
   token: process.env.TOKEN, // logentries TOKEN
+  newline: true, // Split on newline delimited entries
   stats: true, // disable stats if false
   add: null, // an object whose properties will be added
 

--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ function cli() {
     alias: {
       'token': 't',
       'logstoken': 'l',
+      'newline': 'n',
       'statstoken': 'k',
       'eventstoken': 'e',
       'secure': 's',
@@ -157,6 +158,7 @@ function cli() {
     },
     default: {
       json: false,
+      newline: true,
       stats: true,
       logs: true,
       dockerEvents: true,
@@ -172,7 +174,7 @@ function cli() {
   if (argv.help || !(argv.token || argv.logstoken || argv.statstoken || argv.eventstoken)) {
     console.log('Usage: docker-logentries [-l LOGSTOKEN] [-k STATSTOKEN] [-e EVENTSTOKEN]\n' +
                 '                         [-t TOKEN] [--secure] [--json]\n' +
-                '                         [--no-stats] [--no-logs] [--no-dockerEvents]\n' +
+                '                         [--no-newline] [--no-stats] [--no-logs] [--no-dockerEvents]\n' +
                 '                         [-i STATSINTERVAL] [-a KEY=VALUE]\n' +
                 '                         [--matchByImage REGEXP] [--matchByName REGEXP]\n' +
                 '                         [--skipByImage REGEXP] [--skipByName REGEXP]\n' +

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "docker-allcontainers": "^0.4.0",
     "docker-event-log": "^0.1.2",
-    "docker-loghose": "^0.6.0",
+    "docker-loghose": "^0.7.0",
     "docker-stats": "^0.5.0",
     "dockerode": "^2.2.2",
     "end-of-stream": "^1.1.0",


### PR DESCRIPTION
Hi,

We have noticed that for containers with a lot of output we are getting multiple lines merged, which means that we are not getting well formed JSON output and we are not able to query it. 
I have added an option ( --newline  ) to docker loghose which buffers the chunks until it sees a newline. It has been merged here https://github.com/mcollina/docker-loghose/pull/3 .


What we were getting in logentries is:

``` 2 Aug 2015 22:01:57.196  {
  "v": 0,
  "id": "5a461e5ef42c",
  "image": "rubycontainer_web",
  "name": "rubycontainer_web_1",
  "line": "{\"log\":17200}\n{\"log\":17201}\n{\"log\":17202}\n{\"log\":17203}\n{\"log\":17204}\n{\"log\":17205}\n{\"log\":17206}\n{\"log\":17207}\n{\"log\":17208}\n"
} Context ```


With the update to loghose it should shows: 

``` 22 Aug 2015 22:00:54.474  {
  "v": 0,
  "id": "440a7e5b71de",
  "image": "rubycontainer_web",
  "name": "rubycontainer_web_1",
  "line": {
    "log": 17
  }
} Context ```

This commit updates loghose version, feel free to merge if you it's ok with you.

Thanks for the library
cheers