### PR TITLE
Introducing Alpine node & build system

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Makefile
+README.md
+dashboard.png
+example.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # docker-logentries
 #
-# VERSION 0.2.0
+# VERSION 1.0.0
 
-FROM node:0.12-onbuild
+FROM mhart/alpine-node:5.10.1
 MAINTAINER Matteo Collina <hello@matteocollina.com>
 
 ENTRYPOINT ["/usr/src/app/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM mhart/alpine-node:5.10.1
 MAINTAINER Matteo Collina <hello@matteocollina.com>
+RUN apk add --no-cache bash
 
 ENTRYPOINT ["/usr/src/app/index.js"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 # docker-logentries
 #
-# VERSION 1.0.0
+# VERSION 0.2.0
 
-FROM mhart/alpine-node:5.10.1
+FROM node:0.12-onbuild
 MAINTAINER Matteo Collina <hello@matteocollina.com>
-RUN apk add --no-cache bash
 
 WORKDIR /usr/src/app
 COPY package.json package.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,10 @@ FROM mhart/alpine-node:5.10.1
 MAINTAINER Matteo Collina <hello@matteocollina.com>
 RUN apk add --no-cache bash
 
+WORKDIR /usr/src/app
+COPY package.json package.json
+RUN npm install --production
+COPY index.js /usr/src/app/index.js
+
 ENTRYPOINT ["/usr/src/app/index.js"]
 CMD []

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,6 +9,7 @@ RUN apk add --no-cache bash
 WORKDIR /usr/src/app
 COPY package.json package.json
 RUN npm install --production
+RUN npm cache clean
 COPY index.js /usr/src/app/index.js
 
 ENTRYPOINT ["/usr/src/app/index.js"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,15 @@
+# docker-logentries
+#
+# VERSION 1.0.0
+
+FROM mhart/alpine-node:5.10.1
+MAINTAINER Matteo Collina <hello@matteocollina.com>
+RUN apk add --no-cache bash
+
+WORKDIR /usr/src/app
+COPY package.json package.json
+RUN npm install --production
+COPY index.js /usr/src/app/index.js
+
+ENTRYPOINT ["/usr/src/app/index.js"]
+CMD []

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+NODE_VERSION ?=$(shell grep FROM Dockerfile | cut -d ':' -f 2| cut -d '-' -f 1)
+
+# We support two build modes , node-onbuild or alpine-node
+BUILD_TYPE ?=node-onbuild
+
+NAME_BUILD_CONTAINER ?=logentries-build-$(BUILD_TYPE)
+NAME_TEST_CONTAINER ?=logentries-test-$(BUILD_TYPE)
+
+DOCKER_REGISTRY_PREFIX ?=logentries/logentries
+DOCKER_REGISTRY_IMAGE_TAG_VERSION ?=$(shell node -e "console.log(require('./package.json').version);")
+
+# Use the alpine node 
+ifeq ($(BUILD_TYPE),alpine-node)
+DOCKERFILE_SUFFIX ?=.alpine
+DOCKER_REGISTRY_IMAGE_TAG_PREFIX ?=alpine-
+else
+DOCKERFILE_SUFFIX ?=
+DOCKER_REGISTRY_IMAGE_TAG_PREFIX ?=
+endif
+
+# Just a random token
+LOGENTRIES_TOKEN ?=XAXAXAXAXA
+WAIT_TIME ?=5
+
+.PHONY: default
+default: help
+
+build: ## Builds a new docker image
+	echo $(BUILD_TYPE)
+	echo $(DOCKERFILE_SUFFIX)
+	@echo "[build] Building new image"
+	docker build --rm=true --tag=$(NAME_BUILD_CONTAINER) -f Dockerfile$(DOCKERFILE_SUFFIX) . 
+
+test: ## Tests a previous build docker image to see if starts
+	@echo "[test] Removing existing test container if any"
+	@docker rm -f $(NAME_TEST_CONTAINER) > /dev/null 2>&1 || true
+	@echo "[test] Starting a test container"
+	@docker run -d --name=$(NAME_TEST_CONTAINER) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+  $(NAME_BUILD_CONTAINER) -t $(LOGENTRIES_TOKEN) -j -a host=$(NAME_TEST_CONTAINER)  > /dev/null 2>&1
+	@echo "[test] Testing if the container stays running"
+	@echo "[test] Waiting for $(WAIT_TIME) seconds"
+	@sleep $(WAIT_TIME)
+	@docker ps | grep $(NAME_TEST_CONTAINER) | wc -l
+	@echo "[test] Cleaning up test container $(NAME_TEST_CONTAINER)"
+	@docker rm -f $(NAME_TEST_CONTAINER) > /dev/null 2>&1 || true
+
+tag: ## Tags a local build image to make it ready for push to docker registry
+	docker tag -f $(shell docker images -q $(NAME_BUILD_CONTAINER)) $(DOCKER_REGISTRY_PREFIX):$(DOCKER_REGISTRY_IMAGE_TAG_PREFIX)$(DOCKER_REGISTRY_IMAGE_TAG_VERSION)
+
+
+push: ## Push the local image to the docker registry
+	docker push $(DOCKER_REGISTRY_PREFIX):$(DOCKER_REGISTRY_IMAGE_TAG_PREFIX)$(DOCKER_REGISTRY_IMAGE_TAG_VERSION)
+
+help: ## Shows help
+	@echo "================================================================================================="
+	@echo "support build types are:"
+	@echo "- BUILD_TYPE=node-onbuild (default)"
+	@echo "- BUILD_TYPE=alpine-node"
+	@echo ""
+	@echo "set the environment accordingly to change the build type"
+	@echo "================================================================================================="
+	@IFS=$$'\n' ; \
+    help_lines=(`fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//'`); \
+    for help_line in $${help_lines[@]}; do \
+        IFS=$$'#' ; \
+        help_split=($$help_line) ; \
+        help_command=`echo $${help_split[0]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+        help_info=`echo $${help_split[2]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+        printf "%-30s %s\n" $$help_command $$help_info ; \
+    done

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BUILD_TYPE ?=node-onbuild
 
 NAME_BUILD_CONTAINER ?=logentries-build-$(BUILD_TYPE)
 NAME_TEST_CONTAINER ?=logentries-test-$(BUILD_TYPE)
+NAME_EXPORT_CONTAINER ?=logentries-export-$(BUILD_TYPE)
 
 DOCKER_REGISTRY_PREFIX ?=logentries/logentries
 DOCKER_REGISTRY_IMAGE_TAG_VERSION ?=$(shell node -e "console.log(require('./package.json').version);")
@@ -52,6 +53,11 @@ tag: ## Tags a local build image to make it ready for push to docker registry
 push: ## Push the local image to the docker registry
 	docker push $(DOCKER_REGISTRY_PREFIX):$(DOCKER_REGISTRY_IMAGE_TAG_PREFIX)$(DOCKER_REGISTRY_IMAGE_TAG_VERSION)
 
+export: ## Export the build as a tarball
+	-docker rm -f $(NAME_EXPORT_CONTAINER)
+	docker create --name $(NAME_EXPORT_CONTAINER) $(NAME_BUILD_CONTAINER)
+	docker export -o logentries-$(DOCKER_REGISTRY_IMAGE_TAG_PREFIX)$(DOCKER_REGISTRY_IMAGE_TAG_VERSION).tar `docker ps -a -q -f 'name=$(NAME_EXPORT_CONTAINER)'`
+
 help: ## Shows help
 	@echo "================================================================================================="
 	@echo "support build types are:"
@@ -69,3 +75,4 @@ help: ## Shows help
         help_info=`echo $${help_split[2]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
         printf "%-30s %s\n" $$help_command $$help_info ; \
     done
+

--- a/README.md
+++ b/README.md
@@ -113,11 +113,34 @@ setTimeout(function() {
 
 ## Building a docker repo from this repository
 
+### Using the plain docker file
 First clone this repository, then:
 
 ```bash
 docker build -t logentries .
 docker run -v /var/run/docker.sock:/var/run/docker.sock logentries -t <TOKEN> -j -a host=`uname -n`
+```
+### Using Make - the official nodejs onbuild image 
+```bash
+export BUILD_TYPE=node-onbuild
+make build
+make test
+make tag
+```
+
+### Using Make - the alpine linx build (~42Mb)
+```bash
+export BUILD_TYPE=alpine-node
+make build
+make test
+make tag
+```
+
+### Pushing to your own repo
+After you've build, tested, tagged it locally
+```bash
+export DOCKER_REGISTRY_PREFIX=you-dockerhub-user/yourimage-name
+make push
 ```
 
 ## How it works


### PR DESCRIPTION
a) The base image of logentries is pretty big.
I've added support for alpine-linux making the image around 42 MB.
used the node v5 version instead of the deprecated 0.12 version

b) Added a simple Makefile for build both type of images, made sure the existing file stayed Dockerfile
c) added a .dockerignore file to avoid rebuilds
d) update build documentation
