### PR TITLE
Switch to regular user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,31 @@
 # docker-logentries
 #
 # VERSION 0.2.0
-
-FROM node:0.12-onbuild
+FROM node
 MAINTAINER Matteo Collina <hello@matteocollina.com>
+
+# GoSu work
+ENV GOSU_VERSION 1.9
+RUN apt-get update \
+    && apt-get install -y \
+        curl \
+    && gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && apt-get clean \
+    && apt-get autoremove -y \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 COPY package.json package.json
 RUN npm install --production
 COPY index.js /usr/src/app/index.js
 
-ENTRYPOINT ["/usr/src/app/index.js"]
-CMD []
+ADD run.sh /usr/src/run.sh
+RUN chmod +x /usr/src/run.sh
+
+ENTRYPOINT /usr/src/run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+useradd node
+chown -R node:node /usr/src 
+
+gosu node:${GID} /usr/src/app/index.js --secure -i 60 -l "$logs" -k "$stats" -e "$events"


### PR DESCRIPTION
This example uses gosu to switch to a regular user when running the container.
Running as root in a container is very dangerous and should be avoided.

Example usage:
```
docker build -t logger .
docker run -d \
    -v /var/run/docker.sock:/var/run/docker.sock \
    --name logger \
    -e "GID=$(getent group docker | cut -d: -f3)" \
    -e "logs=xxx" \
    -e "stats=xxx" \
    -e "events=xxx" \
    --restart=on-failure:5 \
    --security-opt=no-new-privileges \
    --memory='1g' \
    --cpu-shares=1024 \
    logger

```